### PR TITLE
Handle unicode issue in python2, when loading string data from json

### DIFF
--- a/bin/edm_pset_pickler.py
+++ b/bin/edm_pset_pickler.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import FWCore.ParameterSet.Config as cms
+import pickle
+try: 
+   import argparse
+except ImportError:  #get it from this package instead
+   import archived_argparse as argparse 
+import sys, re, os
+
+
+def init_argparse():
+   parser = argparse.ArgumentParser(
+      usage="%(prog)s [OPTION] [FILE]...",
+      description="Pickle a pset file"
+   )
+   
+   parser.add_argument('--input', required=True)
+   parser.add_argument('--output_pkl', required=True)
+   return parser
+
+def main():
+    parser = init_argparse()
+    args = parser.parse_args()
+
+    with open(args.input) as f:
+        code = compile(f.read(), args.input, 'exec')
+        exec(code, globals(), locals())
+
+    with open(args.output_pkl, "wb") as pHandle:
+        pickle.dump(process, pHandle)
+
+main()

--- a/bin/edm_pset_tweak.py
+++ b/bin/edm_pset_tweak.py
@@ -23,7 +23,28 @@ except ImportError: #get it from this package instead
 import sys
 import json
 
+def convert_unicode_to_str(data):
+    PY3 = sys.version_info[0] == 3
+    if PY3:
+        return data
+    if type(data) in (int, float, str, bool):
+            return data
+    elif type(data) == unicode:
+            return str(data)
+    elif type(data) in (list, tuple, set):
+            data = list(data)
+            for i,v in enumerate(data):
+                    data[i] = convert_unicode_to_str(v)
+    elif type(data) == dict:
+            for i,v in data.iteritems():
+                    data[i] = convert_unicode_to_str(v)
+    else:
+            print("invalid dataect in data, converting to string")
+            data = str(data) 
+    return data
+
 def apply_tweak(process, key, value, skip_if_set):
+    value = convert_unicode_to_str(value)
     key_split = key.split('.')
     param=process
     if key_split[0] == "process":
@@ -37,7 +58,6 @@ def apply_tweak(process, key, value, skip_if_set):
     if skip_if_set and hasattr(param,key_split[-1]): 
        print("Attribute already set "+key+". Not changing")
        return 0
-
     setattr(param,key_split[-1],value)
     print("Set attribute "+key+" to "+str(getattr(param,key_split[-1])))
     return 0

--- a/bin/edm_pset_tweak.py
+++ b/bin/edm_pset_tweak.py
@@ -45,6 +45,11 @@ def convert_unicode_to_str(data):
 
 def apply_tweak(process, key, value, skip_if_set):
     value = convert_unicode_to_str(value)
+    # Allow setting specific types from json
+    if isinstance(value, str):
+        value_split = value.split('.')
+        if value_split[0] == "customTypeCms":
+            value = eval('cms.{0}'.format('.'.join(value_split[1:])))
     key_split = key.split('.')
     param=process
     if key_split[0] == "process":


### PR DESCRIPTION
String values loaded from json are imported as unicode. This conflicts with cms.string in the FWCore Mixins class, failing with:

```
Traceback (most recent call last):
  File "/cvmfs/cms.cern.ch/share/overrides/bin/edm_pset_tweak.py", line 118, in <module>
    main()
  File "/cvmfs/cms.cern.ch/share/overrides/bin/edm_pset_tweak.py", line 105, in main
    err_val = apply_tweak(process, tweak[0], tweak[1],args.skip_if_set)
  File "/cvmfs/cms.cern.ch/share/overrides/bin/edm_pset_tweak.py", line 41, in apply_tweak
    setattr(param,key_split[-1],value)
  File "/cvmfs/cms.cern.ch/slc7_amd64_gcc820/cms/cmssw-patch/CMSSW_10_6_19_patch3/python/FWCore/ParameterSet/Mixins.py", line 266, in __setattr__
    self.__dict__[name].setValue(value)
  File "/cvmfs/cms.cern.ch/slc7_amd64_gcc820/cms/cmssw-patch/CMSSW_10_6_19_patch3/python/FWCore/ParameterSet/Mixins.py", line 97, in setValue
    raise ValueError(str(value)+" is not a valid "+str(type(self)))
ValueError: testTag is not a valid <class 'FWCore.ParameterSet.Types.string'>
```
When we don't use py3, this PR converts unicode to str to workaround that issue.