### PR TITLE
Update edm_pset_pickler.py

### DIFF
--- a/bin/edm_pset_pickler.py
+++ b/bin/edm_pset_pickler.py
@@ -8,6 +8,8 @@ except ImportError:  #get it from this package instead
    import archived_argparse as argparse 
 import sys, re, os
 
+# Use the same default protocol as in python 2.
+pickle.DEFAULT_PROTOCOL = 0
 
 def init_argparse():
    parser = argparse.ArgumentParser(


### PR DESCRIPTION
Hardcode default pickle protocol to the default protocol number in python 2.