### PR TITLE
enable custom timeout

### DIFF
--- a/bin/cmssw_enable_custom_timeout.py
+++ b/bin/cmssw_enable_custom_timeout.py
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+""":"
+
+python_cmd="python"
+python3 -c "from FWCore.PythonFramework.CmsRun import CmsRun" 2>/dev/null && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+
+"""
+
+import sys, os
+sys.path.insert(0, os.path.join( os.path.dirname(os.path.abspath(__file__)), '..', 'python'))
+
+import FWCore.ParameterSet.Config as cms
+import pickle
+try: 
+   import argparse
+except ImportError:  #get it from this package instead
+   import archived_argparse as argparse 
+import re
+
+from tweak_program_helpers import make_parser, do_loop, get_cmssw_version, isCMSSWSupported
+
+
+
+def custom_timeout(process, args):
+
+   # XrdAdaptor uses 3*60 unless non-zero value is specified here
+   timeout = args.timeout
+   if hasattr(process, "SiteLocalConfigService"):
+      process.SiteLocalConfigService.overrideSourceTimeout = cms.untracked.uint32(timeout)
+   else:
+      process.add_(cms.Service("SiteLocalConfigService",
+                               overrideSourceTimeout = cms.untracked.uint32(timeout)))
+   
+   return process
+
+def init_argparse():
+    parser = make_parser("Enable custom timeout service")
+    parser.add_argument('--timeout', type=int, default=600, required=False)
+    return parser
+
+
+def main():
+    parser = init_argparse()
+    args = parser.parse_args()
+
+    do_loop(args, custom_timeout)
+
+main()

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -136,6 +136,22 @@ fi
 echo ""
 rm -f pset_new.pkl
 
+# do custom timeout
+echo "Testing... custom timeout"
+$test_dir/../bin/cmssw_enable_custom_timeout.py --input_pkl $test_dir/reco.pkl --output_pkl pset_new.pkl --timeout 500
+
+if [ $? -eq 0 ]
+then
+  echo "Custom timeout applied correctly, lets check it"
+  $test_dir/get_pset_param.py --input_pkl $test_dir/reco.pkl pset_new.pkl --param SiteLocalConfigService.overrideSourceTimeout --output out_timeout.json
+else
+  echo "Custom timeout to fix disabled source error" >&2
+  exit 1
+fi
+
+echo ""
+rm -f pset_new.pkl
+
 # do dqmsaver
 echo "Testing...dqmsaver"
 $test_dir/../bin/cmssw_handle_dqm_filesaver.py --input_pkl $test_dir/reco.pkl --output_pkl pset_new.pkl --multiRun --datasetName myDataset


### PR DESCRIPTION
I am proposing the addition of this new script in order to help the debugging of current cmssw issue: https://github.com/cms-sw/cmssw/issues/43162

Specifically, the comment that suggests the content in the new file is: https://github.com/cms-sw/cmssw/issues/43162#issuecomment-1791639746

The file is based on [cmssw_enable_lazy_download.p](https://github.com/cms-sw/cmssw-wm-tools/blob/30b626d030b7b11f83fe4e0385ce303e83d3fcdf/bin/cmssw_enable_lazy_download.py), which modifies the PSet.py file parallel to how we need to modify it this time around.

